### PR TITLE
Move data-cy tag to correct part of the template in 

### DIFF
--- a/src/components/Radio.vue
+++ b/src/components/Radio.vue
@@ -7,11 +7,11 @@
     </legend>
     <div v-for="item in items"
         :key="item.value"
-        :data-cy="getCypressValue(item)"
         class='md-radio'>
       <input type='radio'
             :id='item.id'
             :name='name'
+            :data-cy="getCypressValue(item)"
             :value='item.value'
             v-model='selectedValue'
             @change="onChangeValue($event)"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [x] Tests for these changes were added (if applicable)
- [x] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Hot fix for a recent pull request. Due to data-cy element being on the <div> tag instead of the <input> tag, end to end test failed as click did not successfully reach the input tag like it needed to. 

Tested in Cypress with NPM link, and it works as expected now. I also checked the rest of the common library to see if any other components had this problem, but this seems to only be the one.

### Additional Notes:
Sorry for the inconvenience here; I wasn't able to test in Cypress directly before, so this escaped my notice, but I'm hopeful there won't be any further problems.
