### PR TITLE
add data-cy to open DatePicker

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -43,6 +43,7 @@
             maxlength="4"
             v-on:keypress="isNumber($event)"/>
         <div class="date-picker-icon"
+            :data-cy="getCypressValue('DatePicker')"
             @click="openCloseDatePicker($event)">
           <IconCalendar />
         </div>

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -43,7 +43,7 @@
             maxlength="4"
             v-on:keypress="isNumber($event)"/>
         <div class="date-picker-icon"
-            :data-cy="getCypressValue('DatePicker')"
+            :data-cy="getCypressValue('CalendarIcon')"
             @click="openCloseDatePicker($event)">
           <IconCalendar />
         </div>

--- a/tests/unit/components/DateInput.spec.js
+++ b/tests/unit/components/DateInput.spec.js
@@ -281,6 +281,6 @@ describe('DateInput getCypressValue()', () => {
     expect(wrapper.find("[data-cy=potatoYear]").exists()).toBe(true)
     expect(wrapper.find("[data-cy=potatoDay]").exists()).toBe(true)
     expect(wrapper.find("[data-cy=potatoMonth1]").exists()).toBe(true)
-    expect(wrapper.find("[data-cy=potatoDatePicker]").exists()).toBe(true)
+    expect(wrapper.find("[data-cy=potatoCalendarIcon]").exists()).toBe(true)
   });
 });

--- a/tests/unit/components/DateInput.spec.js
+++ b/tests/unit/components/DateInput.spec.js
@@ -281,5 +281,6 @@ describe('DateInput getCypressValue()', () => {
     expect(wrapper.find("[data-cy=potatoYear]").exists()).toBe(true)
     expect(wrapper.find("[data-cy=potatoDay]").exists()).toBe(true)
     expect(wrapper.find("[data-cy=potatoMonth1]").exists()).toBe(true)
+    expect(wrapper.find("[data-cy=potatoDatePicker]").exists()).toBe(true)
   });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [X] Tests for these changes were added (if applicable)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Adds data-cy value to the icon in the DateInput.vue component. This allows me to click it and open the DatePicker during testing without having to use a class selector.

### Additional Notes:
Checked test and app state with NPM link to ensure functionality.