### PR TITLE
fix: CurrencyInput inputStyle apply to input group

### DIFF
--- a/src/components/CurrencyInput.vue
+++ b/src/components/CurrencyInput.vue
@@ -4,7 +4,7 @@
       {{label}}<span v-if="isRequiredAsteriskShown" class="required-asterisk">*</span>
     </label>
     <br/>
-    <div class="input-group">
+    <div class="input-group" :style='inputStyle'>
       <div class="input-group-prepend">
         <span class="input-group-text">$</span>
       </div>
@@ -12,7 +12,6 @@
         class='form-control'
         v-model="formattedValue"
         :maxlength='maxlength'
-        :style='inputStyle'
         :data-cy="getCypressValue()"
         :readonly='readonly'
         :disabled='disabled'


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X ] After these changes, the app was run and still works as expected
- [ ] Tests for these changes were added (if applicable)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Applied inputStyle to the input group instead of the input itself.
### Additional Notes:
This fixes a bug where the input appeared to be the maximum width when the input field inside is medium or small. 