### PR TITLE
Fixed IE regex use, and leading zero bug in `CurrencyInput` component.

### DIFF
--- a/src/components/CurrencyInput.vue
+++ b/src/components/CurrencyInput.vue
@@ -110,7 +110,8 @@ export default {
       const inputValue = event.target.value;
       const value = this.removeCommas(inputValue).trim();
       
-      if (isValidCurrencyAmount(value)) {
+      if (isValidCurrencyAmount(value)
+        && !(value.length > 1 && value[0] === '0' && !isNaN(parseInt(value[1])))) {
         this.formattedValue = convertNumberToFormattedString(value);
         this.$emit('input', value);
       } else {

--- a/src/helpers/string.js
+++ b/src/helpers/string.js
@@ -878,7 +878,26 @@ export const convertNumberToFormattedString = (value) => {
     && typeof value !== 'string') {
     return value;
   }
-  let result = `${value}`;
-  result = result.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',');
+  const parts = `${value}`.split('.');
+  const roundValue = parts[0];
+  const decimalValue = parts[1];
+  let result = '';
+
+  if (!roundValue) {
+    return '';
+  }
+
+  let unitPosition = 0;
+  for (let i=roundValue.length-1; i>=0; i--) {
+    result = `${roundValue[i]}${result}`;
+    unitPosition++
+    if (i > 0 && unitPosition === 3) {
+      result = `,${result}`;
+      unitPosition = 0;
+    }
+  }
+  if (decimalValue || (typeof value === 'string' && value.includes('.'))) {
+    result = `${result}.${decimalValue}`;
+  }
   return result;
 };

--- a/tests/unit/helpers/string.spec.js
+++ b/tests/unit/helpers/string.spec.js
@@ -78,6 +78,8 @@ describe('String helpers', () => {
     expect(convertNumberToFormattedString('1234.9999')).toBe('1,234.9999');
     expect(convertNumberToFormattedString(1234567.9999)).toBe('1,234,567.9999');
     expect(convertNumberToFormattedString('1234567.9999')).toBe('1,234,567.9999');
+    expect(convertNumberToFormattedString('1234.')).toBe('1,234.');
+    expect(convertNumberToFormattedString('')).toBe('');
     expect(convertNumberToFormattedString(undefined)).toBe(undefined);
     expect(convertNumberToFormattedString(null)).toBe(null);
     expect(convertNumberToFormattedString(NaN)).toBe(NaN);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [x] Tests for these changes were added (if applicable)
- [x] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):

### Additional Notes:

IE11 isn't compatible with back-referencing regex, so I had to rewrite the number formatter.