### PR TITLE
feat: Country/RegionSelect disablePlaceholder prop

### DIFF
--- a/src/components/CountrySelect.vue
+++ b/src/components/CountrySelect.vue
@@ -74,7 +74,7 @@ export default {
   },
   methods: {
     handleInput(value) {
-        this.$emit('input', value);
+      this.$emit('input', value);
     }
   }
 }

--- a/src/components/CountrySelect.vue
+++ b/src/components/CountrySelect.vue
@@ -17,6 +17,7 @@
       :countryName="true"
       topCountry="Canada"
       :placeholder="defaultOptionLabel"
+      :disablePlaceholder="disablePlaceholder"
       @input="handleInput($event)"
       @blur="handleBlur($event)"/>
   </div>
@@ -66,10 +67,14 @@ export default {
       type: Boolean,
       default: false
     },
+    disablePlaceholder: {
+      type: Boolean,
+      default: false,
+    },
   },
   methods: {
     handleInput(value) {
-      this.$emit('input', value);
+        this.$emit('input', value);
     }
   }
 }

--- a/src/components/RegionSelect.vue
+++ b/src/components/RegionSelect.vue
@@ -18,6 +18,7 @@
       :countryName="true"
       :regionName="true"
       :placeholder="defaultOptionLabel"
+      :disablePlaceholder="disablePlaceholder"
       @input="handleInput($event)"
       @blur="handleBlur($event)" />
   </div>
@@ -74,7 +75,11 @@ export default {
     disabled: {
       type: Boolean,
       default: false
-    }
+    },
+    disablePlaceholder: {
+      type: Boolean,
+      default: false,
+    },
   },
   methods: {
     handleInput(value) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [ ] Tests for these changes were added (if applicable)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
for CountrySelect and RegionSelect Components add a prop to block the user from selecting the default placeholder (eg. "Select a Country" cannot be selected).
### Additional Notes:
