### PR TITLE
rmeove re-emmision of click event

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -2,7 +2,6 @@
   <button
     :class="classes"
     :data-cy='getCypressValue()'
-    @click="$emit('click', $event)"
     :disabled="disabled || hasLoader">
     <div v-if="hasLoader" class="bcgov-loader-show">
       <Loader />

--- a/stories/components/Button.stories.js
+++ b/stories/components/Button.stories.js
@@ -3,13 +3,18 @@ import Button from '../../src/components/Button.vue';
 export default {
   title: 'Components/Button',
   component: Button,
-  argTypes: {},
+  argTypes: {
+    color: {
+      options: ['blue', 'white', 'gold'],
+      control: { type: 'select' },
+    }
+  },
 };
 
-const Template = (args, { argTypes }) => ({
-  props: Object.keys(argTypes),
+const Template = (args) => ({
   components: { Button },
-  template: '<Button v-bind="$props" />',
+  setup() { return { args }; },
+  template: '<Button v-bind="args" />',
 });
 
 export const Example = Template.bind({});


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [ ] After these changes, the app was run and still works as expected
- [ ] Tests for these changes were added (if applicable)
- [ ] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Bug fix
### Additional Notes:
Found docs for the changes to event logic for vue3 [here](https://v3-migration.vuejs.org/breaking-changes/emits-option.html#example). Since this is just re-emmitting the event I followed the second option and removed it instead of including `click` in the emits array (This works in the Button.spec.js test which catches 1 click event as expected).