### PR TITLE
Timeinput

### DIFF
--- a/src/components/TimeInput.vue
+++ b/src/components/TimeInput.vue
@@ -120,8 +120,8 @@ export default {
   ],
   data() {
     return {
-      hour: null,
-      minute: null,
+      hour: "",
+      minute: "",
       hours: [
       ],
       minutes: [
@@ -131,8 +131,8 @@ export default {
   watch: {
     modelValue(value) {
       if (value) {
-        this.hour = value.hour;
-        this.minute = value.minute;
+        this.hour = value.hour ? value.hour : "";
+        this.minute = value.minute ? value.minute : "";
       } else {
         this.hour = "";
         this.minute = "";
@@ -144,8 +144,8 @@ export default {
   },
   created() {
     if (this.modelValue) {
-      this.hour = this.modelValue.hour;
-      this.minute = this.modelValue.minute;
+      this.hour = this.modelValue.hour ? this.modelValue.hour : "";
+      this.minute = this.modelValue.minute ? this.modelValue.minute : "";
 
       if (!this.modelValue.time) {
         this.writeModel();

--- a/src/components/TimeInput.vue
+++ b/src/components/TimeInput.vue
@@ -25,7 +25,7 @@
         >
           <!-- We show the blank option so the user can clear out their data.-->
           <option
-            :value="null"
+            value=""
           >
             {{ isHourTwoDigits ? 'HH' : 'H' }}
           </option>
@@ -58,7 +58,7 @@
         >
           <!-- We show the blank option so the user can clear out their data.-->
           <option
-            :value="null"
+            value=""
           >
             MM
           </option>
@@ -134,8 +134,8 @@ export default {
         this.hour = value.hour;
         this.minute = value.minute;
       } else {
-        this.hour = null;
-        this.minute = null;
+        this.hour = "";
+        this.minute = "";
       }
     },
     isHourTwoDigits() {
@@ -181,25 +181,22 @@ export default {
     },
     changeHourHandler(event) {
       const value = event.target.value
-      this.hour = value ? value : null;
+      this.hour = value ? value : "";
       this.writeModel();
     },
     changeMinuteHandler(event) {
       const value = event.target.value;
-      this.minute = value ? value : null;
+      this.minute = value ? value : "";
       this.writeModel();
     },
     writeModel() {
-      this.$emit('update:modelValue', {
-        hour: this.hour,
-        minute: this.minute,
+      const newTime = {
+        hour: this.hour ? this.hour : null,
+        minute: this.minute ? this.minute : null,
         time: this.isTimeValid() ? this.getTime() : null,
-      });
-      this.$emit('input', {
-        hour: this.hour,
-        minute: this.minute,
-        time: this.isTimeValid() ? this.getTime() : null,
-      });
+      }
+      this.$emit('update:modelValue', newTime);
+      this.$emit('input', newTime);
     },
     isTimeValid() {
       const hour = parseInt(this.hour);

--- a/tests/unit/components/TimeInput.spec.js
+++ b/tests/unit/components/TimeInput.spec.js
@@ -21,24 +21,68 @@ describe('TimeInput getCypressValue()', () => {
 });
 
 describe("TimeInput event handling", () => {
-  it("works correctly with v-model", async () => {
+  const myTime = {
+    hour: '3',
+    minute: '15',
+    time: '3:15',
+  }
+
+  it("loads model data from v-model and updates the value when changing time", async () => {
     const wrapper = mount({
       data() {
-        return { 
-          myTime: {
-            hour: 3,
-            minute: 15,
-            time: '3:15',
-          }
+        return {
+          myTime,
         };
       },
       template: '<div><TimeInput v-model="myTime" /></div>',
       components: { TimeInput },
     });
 
+    expect(wrapper.vm.myTime.minute).toBe('15');
+    expect(wrapper.vm.myTime.hour).toBe('3');
     expect(wrapper.vm.myTime.time).toBe('3:15');
-    await wrapper.find('.hour-select').setValue(4);
-    await wrapper.find('.minute-select').setValue(25);
-    expect(wrapper.vm.myTime.time).toBe('4:25');
+
+    const minuteSelect = wrapper.find('#-minute-select');
+    const hourSelect = wrapper.find('#-hour-select');
+    const minuteOptions = await minuteSelect.findAll('option');
+    const hourOptions = await hourSelect.findAll('option');
+
+    // Option indices one higher due to default option
+    await hourOptions.at(10).setSelected();
+    await minuteOptions.at(43).setSelected();
+    expect(wrapper.vm.myTime.hour).toBe('9');
+    expect(wrapper.vm.myTime.minute).toBe('42');
+    expect(wrapper.vm.myTime.time).toBe('9:42');
   });
+
+  it("updates model value to null and shows the default option when clearing the select fields", async () => {
+    const wrapper = mount({
+      data() {
+        return {
+          myTime,
+        };
+      },
+      template: '<div><TimeInput v-model="myTime" /></div>',
+      components: { TimeInput },
+    });
+
+    const minuteSelect = wrapper.find('#-minute-select');
+    const hourSelect = wrapper.find('#-hour-select');
+    const minuteOptions = await minuteSelect.findAll('option');
+    const hourOptions = await hourSelect.findAll('option');
+    
+    expect(minuteSelect.element.value).toBe("15");
+    expect(hourSelect.element.value).toBe("3");
+
+    await hourOptions.at(0).setSelected();
+    expect(wrapper.vm.myTime.time).toBe(null);
+    expect(wrapper.vm.myTime.hour).toBe(null);
+    expect(wrapper.vm.myTime.minute).not.toBe(null);
+    
+    await minuteOptions.at(0).setSelected();
+    expect(wrapper.vm.myTime.minute).toBe(null);
+
+    expect(minuteSelect.element.value).toBe("");
+    expect(hourSelect.element.value).toBe("");
+  })
 });

--- a/tests/unit/components/TimeInput.spec.js
+++ b/tests/unit/components/TimeInput.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import TimeInput from '../../../src/components/TimeInput.vue';
+import { nextTick } from 'vue';
 
 describe('TimeInput.vue', () => {
   it('renders', () => {
@@ -84,5 +85,45 @@ describe("TimeInput event handling", () => {
 
     expect(minuteSelect.element.value).toBe("");
     expect(hourSelect.element.value).toBe("");
+  });
+
+  it('shows default option labels when no initial time is provided or time is cleared in parent', async () => {
+    const wrapper = mount({
+      data() {
+        return {
+          myTime: {
+            minute: null,
+            hour: null,
+            time: null,
+          },
+        };
+      },
+      template: '<div><TimeInput v-model="myTime" /></div>',
+      components: { TimeInput },
+    });
+
+    const timeInput = wrapper.findComponent(TimeInput);
+    expect(timeInput.vm.minute).toBe("");
+    expect(timeInput.vm.hour).toBe("");
+
+    wrapper.vm.myTime = {
+      minute: '15',
+      hour: '4',
+      time: '4:15',
+    }
+
+    await nextTick();
+    expect(timeInput.vm.minute).toBe("15");
+    expect(timeInput.vm.hour).toBe("4");
+  
+    wrapper.vm.myTime = {
+      minute: null,
+      hour: null,
+      time: null,
+    }
+    
+    await nextTick();
+    expect(timeInput.vm.minute).toBe("");
+    expect(timeInput.vm.hour).toBe("");
   })
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [ ] After these changes, the app was run and still works as expected
- [x] Tests for these changes were added (if applicable)
- [x] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Bug fix
### Additional Notes:
Updated `TimeInput` to use an empty string for the local values when the model values are null. Realized that the syntax `:value=null` leaves the value off the `<option>` element altogether which caused a lot of issues (value would fallback to the label text). 